### PR TITLE
chore: customize renovate TypeScript update handling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
     },
     {
       "matchPackageNames": "typescript",
-      "automerge": false,
+      "automerge": false
     }
   ],
   "timezone": "Europe/Warsaw",

--- a/renovate.json
+++ b/renovate.json
@@ -16,11 +16,20 @@
       "prPriority": 5
     },
     {
-      "excludePackageNames": ["@changesets/cli", "@changesets/apply-release-plan", "@changesets/assemble-release-plan"],
+      "excludePackageNames": [
+        "@changesets/cli",
+        "@changesets/apply-release-plan",
+        "@changesets/assemble-release-plan",
+        "typescript"
+      ],
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchPackageNames": "typescript",
+      "automerge": false,
     }
   ],
   "timezone": "Europe/Warsaw",


### PR DESCRIPTION
TypeScript ships breaking changes in minor updates. We should not auto-merge TypeScript updates and instead verify those updates manually.