### PR TITLE
feat: require module

### DIFF
--- a/.changeset/odd-suits-destroy.md
+++ b/.changeset/odd-suits-destroy.md
@@ -1,0 +1,5 @@
+---
+"@theguild/prettier-config": patch
+---
+
+Use `require` statements for working around the VSCode plugin being unable to resolve the plugin modules.

--- a/packages/prettier-config/index.cjs
+++ b/packages/prettier-config/index.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: [
     // for prettifying shellscript, Dockerfile, properties, gitignore, dotenv
-    'prettier-plugin-sh',
+    require('prettier-plugin-sh'),
   ],
 };


### PR DESCRIPTION
Visual Studio Code (and the prettier plugin) has issues resolving the correct module via the string. After changing the statement to a require statement everything works fine.