### PR TITLE
fix: override renovate ignore paths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,5 +33,11 @@
     }
   ],
   "timezone": "Europe/Warsaw",
-  "schedule": ["after 10pm and before 6:00am"]
+  "schedule": ["after 10pm and before 6:00am"],
+  "ignorePaths": [
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ]
 }


### PR DESCRIPTION
Currently, renovate does not update `examples`. 😭

This overrides the ignorePaths.