### PR TITLE
add `package.json` to `exports` field

### DIFF
--- a/.changeset/giant-bats-invent.md
+++ b/.changeset/giant-bats-invent.md
@@ -1,0 +1,7 @@
+---
+'@theguild/eslint-config': patch
+'@theguild/prettier-config': patch
+'@theguild/tailwind-config': patch
+---
+
+add `package.json` to `exports` field

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -15,7 +15,8 @@
   "private": false,
   "exports": {
     ".": "./src/index.cjs",
-    "./*": "./src/*.cjs"
+    "./*": "./src/*.cjs",
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -14,7 +14,8 @@
   "license": "MIT",
   "private": false,
   "exports": {
-    ".": "./index.cjs"
+    ".": "./index.cjs",
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -15,7 +15,8 @@
   "private": false,
   "exports": {
     ".": "./index.cjs",
-    "./postcss.config": "./postcss.config.cjs"
+    "./postcss.config": "./postcss.config.cjs",
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
fixes warning from storybook
<img width="397" alt="image" src="https://user-images.githubusercontent.com/7361780/195337791-c4a68743-4526-4f24-aadf-52dba0eebab1.png">
