### PR TITLE
add `varsIgnorePattern: '^_'` for `@typescript-eslint/no-unused-vars`

### DIFF
--- a/.changeset/wet-points-tickle.md
+++ b/.changeset/wet-points-tickle.md
@@ -1,0 +1,6 @@
+---
+'@theguild/eslint-config': patch
+---
+
+add `varsIgnorePattern: '^_'` for `@typescript-eslint/no-unused-vars`
+forbid lodash/isString.js, lodash/isArray.js, lodash/flatten.js, lodash/compact.js, lodash/identity.js

--- a/packages/eslint-config/src/base.js
+++ b/packages/eslint-config/src/base.js
@@ -4,6 +4,11 @@ const RESTRICTED_MODULES = [
   { name: 'axios', message: 'Use `fetch/node-fetch` instead.' },
   { name: 'moment', message: 'Use `dayjs/date-fns` instead.' },
   { name: 'classnames', message: 'Use `clsx` instead because he is faster.' },
+  { name: 'lodash/isString.js', message: "Use `typeof yourVar === 'string'` instead." },
+  { name: 'lodash/isArray.js', message: 'Use `Array.isArray` instead.' },
+  { name: 'lodash/flatten.js', message: 'Use `Array#flat()` instead.' },
+  { name: 'lodash/compact.js', message: 'Use `Array#filter(Boolean)` instead.' },
+  { name: 'lodash/identity.js', message: 'Use `(value) => value` instead.' },
 ];
 
 const RESTRICTED_SYNTAX = [
@@ -103,7 +108,13 @@ module.exports = {
     'import/no-default-export': 'error',
     'import/prefer-default-export': 'off', // disable opposite of 'import/no-default-export'
 
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_', // allow underscores in destructuring
+      },
+    ],
 
     // Enforce the style of numeric separators by correctly grouping digits
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/numeric-separators-style.md

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -26,7 +26,14 @@ module.exports = {
       rules: { '@typescript-eslint/no-var-requires': 'off' },
     },
     {
-      files: ['jest.config.js', 'webpack.config.js', 'bob.config.js', 'babel.config.js'],
+      files: [
+        'jest.config.js',
+        'webpack.config.js',
+        'bob.config.js',
+        'babel.config.js',
+        'postcss.config.{js,cjs}',
+        'rollup.config.js',
+      ],
       env: { node: true },
     },
     {
@@ -35,7 +42,13 @@ module.exports = {
       rules: { 'import/extensions': ['error', 'never'] },
     },
     {
-      files: ['vite.config.ts', 'jest.config.js', '*.d.ts', 'website/theme.config.tsx'],
+      files: [
+        'vite.config.ts',
+        'jest.config.js',
+        '*.d.ts',
+        'website/theme.config.tsx',
+        'tsup.config.ts',
+      ],
       rules: { 'import/no-default-export': 'off' },
     },
   ],

--- a/packages/eslint-config/src/react.js
+++ b/packages/eslint-config/src/react.js
@@ -17,6 +17,8 @@ module.exports = {
       files: [
         '**/pages/**', // Next.js pages directory use default export
         'next.config.{js,mjs}',
+        '**/*.stories.tsx',
+        '.storybook/main.ts'
       ],
       rules: {
         'import/no-default-export': 'off',


### PR DESCRIPTION
forbid lodash/isString.js, lodash/isArray.js, lodash/flatten.js, lodash/compact.js, lodash/identity.js