### PR TITLE
ci: cancel previous known runs before starting a new job

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -19,6 +19,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
+
     - name: Setup ${{ inputs.packageManager }}
       id: pnpm_setup
       if: inputs.packageManager == 'pnpm'


### PR DESCRIPTION
This can help optimize CI runs when multiple commits are pushed to a branch in a short period of time
