### PR TITLE
Create ESlint typescript config file for rules like @typescript-eslint/prefer-optional-chain

### DIFF
--- a/.changeset/strange-ravens-matter.md
+++ b/.changeset/strange-ravens-matter.md
@@ -1,0 +1,5 @@
+---
+"@theguild/eslint-config": patch
+---
+
+Fix @typescript-eslint/prefer-optional-chain causing eslint to fail if .js files are not included in tsconfig

--- a/packages/eslint-config/src/base.js
+++ b/packages/eslint-config/src/base.js
@@ -95,7 +95,6 @@ module.exports = {
 
     'prefer-object-has-own': 'error',
     'logical-assignment-operators': ['error', 'always', { enforceForIfStatements: true }],
-    '@typescript-eslint/prefer-optional-chain': 'error',
 
     yoda: 'error',
     'unicorn/prefer-export-from': ['error', { ignoreUsedVariables: true }],

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -15,9 +15,7 @@ module.exports = {
     },
     {
       files: TS_FILE,
-      rules: {
-        '@typescript-eslint/consistent-type-assertions': 'error',
-      },
+      extends: './typescript',
     },
     {
       files: ['*.c{j,t}s'],

--- a/packages/eslint-config/src/typescript.js
+++ b/packages/eslint-config/src/typescript.js
@@ -1,0 +1,7 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  rules: {
+    '@typescript-eslint/consistent-type-assertions': 'error',
+    '@typescript-eslint/prefer-optional-chain': 'error',
+  },
+};


### PR DESCRIPTION
Some rules such as @typescript-eslint/prefer-optional-chain need tsconfig to work correctly. If applied on all files (e.g. .js), ESLint will not work, saying said files are not included in tsconfig.

This PR moves _some_ typescript rules to a dedicated TS rule file.