### PR TITLE
Add @tailwindcss/container-queries

### DIFF
--- a/.changeset/early-toes-brush.md
+++ b/.changeset/early-toes-brush.md
@@ -1,0 +1,5 @@
+---
+"@theguild/tailwind-config": minor
+---
+
+Add `@tailwindcss/container-queries` plugin as `dependency`

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -35,6 +35,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
+    "@tailwindcss/container-queries": "^0.1.1",
     "autoprefixer": "^10.4.19",
     "cssnano": "^7.0.0",
     "postcss": "^8.4.38",

--- a/packages/tailwind-config/src/tailwind.config.ts
+++ b/packages/tailwind-config/src/tailwind.config.ts
@@ -1,4 +1,5 @@
 import { type Config } from 'tailwindcss';
+import tailwindContainerQueries from '@tailwindcss/container-queries';
 import { hiveColors } from './hive-colors';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- tailwindcss types are incorrect
@@ -74,6 +75,7 @@ const config = {
       },
     },
   },
+  plugins: [tailwindContainerQueries],
 } satisfies Config;
 
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
 
   packages/tailwind-config:
     dependencies:
+      '@tailwindcss/container-queries':
+        specifier: ^0.1.1
+        version: 0.1.1(tailwindcss@3.4.10(ts-node@10.9.2(@types/node@20.16.2)(typescript@5.5.4)))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.20(postcss@8.4.43)
@@ -963,6 +966,11 @@ packages:
     resolution: {integrity: sha512-sYUKGaBMXcTEyvMxSECb1H8YPQojgsv6FkUWDN1isLNDrTyk52VETCmRFiS9Aj/hon8W6x8IL5597FyN/SC+qg==}
     peerDependencies:
       eslint: ^8.56.0
+
+  '@tailwindcss/container-queries@0.1.1':
+    resolution: {integrity: sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==}
+    peerDependencies:
+      tailwindcss: '>=3.2.0'
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -5066,6 +5074,10 @@ snapshots:
       - prettier
       - supports-color
       - typescript
+
+  '@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.10(ts-node@10.9.2(@types/node@20.16.2)(typescript@5.5.4)))':
+    dependencies:
+      tailwindcss: 3.4.10(ts-node@10.9.2(@types/node@20.16.2)(typescript@5.5.4))
 
   '@trysound/sax@0.2.0': {}
 


### PR DESCRIPTION
Dima noticed we should move this here, and I like it. I think container queries are useful and they already have very wide support. Best thing — they can easily work as progressive enhancement and the UI still makes sense if they don't work.

<img width="1368" alt="image" src="https://github.com/user-attachments/assets/0a073583-4093-4826-b014-96c3a70182e0">
