### PR TITLE
allow default imports in stories without .tsx extension

### DIFF
--- a/packages/eslint-config/src/react.js
+++ b/packages/eslint-config/src/react.js
@@ -12,7 +12,7 @@ module.exports = {
       files: [
         '**/pages/**', // Next.js pages directory use default export
         'next.config.{js,mjs}',
-        '**/*.stories.tsx',
+        '**/*.stories.{ts,tsx}',
         '.storybook/main.ts',
       ],
       rules: {


### PR DESCRIPTION
This lint error pops up in Hive repo for me. It's annoying because we also have one that forces you to change extension to `.ts` if there's no JSX syntax in the story file.