### PR TITLE
Stop crashing when @theguild/components cannot be imported

### DIFF
--- a/.changeset/@theguild_eslint-config-656-dependencies.md
+++ b/.changeset/@theguild_eslint-config-656-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@theguild/eslint-config": patch
+---
+dependencies updates:
+  - Updated dependency [`eslint-import-resolver-typescript@3.7.0` ↗︎](https://www.npmjs.com/package/eslint-import-resolver-typescript/v/3.7.0) (from `3.6.3`, in `dependencies`)
+  - Updated dependency [`eslint-plugin-promise@7.2.1` ↗︎](https://www.npmjs.com/package/eslint-plugin-promise/v/7.2.1) (from `7.1.0`, in `dependencies`)

--- a/.changeset/empty-flies-shop.md
+++ b/.changeset/empty-flies-shop.md
@@ -1,0 +1,5 @@
+---
+"@theguild/tailwind-config": patch
+---
+
+Stop crashing when @theguild/components cannot be imported

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "shared-configs",
+  "type": "module",
   "description": "Guild's shared configs following our styleguide",
   "repository": "git@github.com:the-guild-org/shared-config.git",
   "author": {

--- a/packages/tailwind-config/src/tailwind.config.ts
+++ b/packages/tailwind-config/src/tailwind.config.ts
@@ -33,6 +33,7 @@ function getComponentsPatterns() {
       path.relative(process.cwd(), path.posix.join(componentsPackageJson, '..', 'dist/**/*.js')),
     ];
   } catch {
+    console.warn("Can't find `@theguild/components` package.")
     return [];
   }
 }

--- a/packages/tailwind-config/src/tailwind.config.ts
+++ b/packages/tailwind-config/src/tailwind.config.ts
@@ -14,23 +14,28 @@ const makePrimaryColor: any =
     return 'hsl(' + h + s + l + (opacityValue ? ` / ${opacityValue}` : '') + ')';
   };
 
-/**
- * We explicitly do not use `import { createRequire } from 'node:module'` and
- * `const require = createRequire(import.meta.url)` because it works even without it.
- * E.g. storybook complains about cannot found `module` package
- */
-const componentsPackageJson = require.resolve('@theguild/components/package.json', {
-  /**
-   * Paths to resolve module location from CWD. Without specifying, it picks incorrect
-   * `@theguild/components`, also must be relative
-   */
-  paths: [process.cwd()],
-});
+function getComponentsPatterns() {
+  try {
+    /**
+     * We explicitly do not use `import { createRequire } from 'node:module'` and
+     * `const require = createRequire(import.meta.url)` because it works even without it.
+     * E.g. storybook complains about cannot found `module` package
+     */
+    const componentsPackageJson = require.resolve('@theguild/components/package.json', {
+      /**
+       * Paths to resolve module location from CWD. Without specifying, it picks incorrect
+       * `@theguild/components`, also must be relative
+       */
+      paths: [process.cwd()],
+    });
 
-const componentsPattern = path.relative(
-  process.cwd(),
-  path.posix.join(componentsPackageJson, '..', 'dist/**/*.js'),
-);
+    return [
+      path.relative(process.cwd(), path.posix.join(componentsPackageJson, '..', 'dist/**/*.js')),
+    ];
+  } catch {
+    return [];
+  }
+}
 
 const config = {
   /**
@@ -38,7 +43,7 @@ const config = {
    * @see https://github.com/tailwindlabs/tailwindcss/pull/12717/files#diff-cf9185e083748e39c6940d3ad337df23b0ecbbd70b9550f596de7cf4b4668bcfR263-R273
    */
   darkMode: ['variant', '&:not(.light *)'],
-  content: ['./{src,app}/**/*.{tsx,mdx}', './mdx-components.tsx', componentsPattern],
+  content: ['./{src,app}/**/*.{tsx,mdx}', './mdx-components.tsx', ...getComponentsPatterns()],
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
### Problem

I was wondering why is Prettier in the Docs/Components repo broken in my editor.

- It imports the Tailwind config (because of the Tailwind plugin)
- and then shared Tailwind config
- and then '@theguild/components/package.json'
- which does exists in this repo only in packages/website/node_modules with workspace:* dependency

### Solution

I’m was thinking of two possible solutions:

- Add @theguild/components to peerDependencies of @theguild/tailwind-config, so PNPM knows to hoist it. There is an implicit dependency now because of this require.resolve. (Update package.json to match the behaviour.)
- Wrap that require.resolve in a try-catch to make @theguild/tailwind-config work even in projects without @theguild/components. (Update behavior to match package.json)

This PR implements the latter one.

### Attachments

![image](https://github.com/user-attachments/assets/da0e113d-929e-46ac-b78d-2bbdac94d3a5)
