### PR TITLE
Fix a wildcard redirects (Nexjs fights with Cloudflare)

### DIFF
--- a/website-cf/action.yml
+++ b/website-cf/action.yml
@@ -61,7 +61,7 @@ runs:
       # NextJS requires `docs/things/:path*` syntax, but that does not work on Cloudflare.
       # Redirects in CF uses `*`.
       # With `:path*` the redirect from "docs/old/:path*" to "docs/new/:path*" becomes "docs/new/foo*"
-      run: sed -i 's|\([^ ]*\):path\* \([^ ]*\):path\* \([0-9]*\)|\1* \2:path \3|' _redirects
+      run: sed -i 's|\([^ ]*\):path\* \([^ ]*\):path\* \([0-9]*\)|\1* \2:splat \3|' _redirects
       working-directory: ${{ format('{0}/{1}', inputs.websiteDirectory, inputs.artifactDir) }}
 
     - name: push to cloudflare pages

--- a/website-cf/action.yml
+++ b/website-cf/action.yml
@@ -61,7 +61,7 @@ runs:
       # NextJS requires `docs/things/:path*` syntax, but that does not work on Cloudflare.
       # Redirects in CF uses `*`.
       # With `:path*` the redirect from "docs/old/:path*" to "docs/new/:path*" becomes "docs/new/foo*"
-      run: sed -i 's/:path\*/\*/g' _redirects
+      run: sed -i 's|\([^ ]*\):path\* \([^ ]*\):path\* \([0-9]*\)|\1* \2:path \3|' _redirects
       working-directory: ${{ format('{0}/{1}', inputs.websiteDirectory, inputs.artifactDir) }}
 
     - name: push to cloudflare pages

--- a/website-cf/action.yml
+++ b/website-cf/action.yml
@@ -59,8 +59,10 @@ runs:
     - name: fix wildcard redirects
       shell: bash
       # NextJS requires `docs/things/:path*` syntax, but that does not work on Cloudflare.
-      # Redirects in CF uses `*`.
+      # Redirects in CF uses `*` and `:splat`.
       # With `:path*` the redirect from "docs/old/:path*" to "docs/new/:path*" becomes "docs/new/foo*"
+      # - /docs/integrations/:path* /docs/other-integrations/:path* 302
+      # + /docs/integrations/* /docs/other-integrations/:splat 302
       run: sed -i 's|\([^ ]*\):path\* \([^ ]*\):path\* \([0-9]*\)|\1* \2:splat \3|' _redirects
       working-directory: ${{ format('{0}/{1}', inputs.websiteDirectory, inputs.artifactDir) }}
 

--- a/website-cf/action.yml
+++ b/website-cf/action.yml
@@ -56,6 +56,14 @@ runs:
       run: ${{ inputs.buildScript }}
       working-directory: ${{ inputs.websiteDirectory }}
 
+    - name: fix wildcard redirects
+      shell: bash
+      # NextJS requires `docs/things/:path*` syntax, but that does not work on Cloudflare.
+      # Redirects in CF uses `*`.
+      # With `:path*` the redirect from "docs/old/:path*" to "docs/new/:path*" becomes "docs/new/foo*"
+      run: sed -i 's/:path\*/\*/g' _redirects
+      working-directory: ${{ format('{0}/{1}', inputs.websiteDirectory, inputs.artifactDir) }}
+
     - name: push to cloudflare pages
       uses: cloudflare/pages-action@v1.5.0
       id: deploy


### PR DESCRIPTION
NextJS requires `docs/things/:path*` syntax, but that does not work on Cloudflare.
Redirects in CF uses `*` and `:splat`.
With `:path*` the redirect from "docs/old/:path*" to "docs/new/:path*" becomes "docs/new/foo*"

```diff
- /docs/integrations/:path* /docs/other-integrations/:path* 302
+ /docs/integrations/* /docs/other-integrations/:splat 302
```