### PR TITLE
Add theme.config.tsx back to avoid "big logo" problems in Nextra 3 websites

### DIFF
--- a/.changeset/nine-ties-begin.md
+++ b/.changeset/nine-ties-begin.md
@@ -1,0 +1,5 @@
+---
+'@theguild/tailwind-config': patch
+---
+
+Add theme.config.tsx back to Tailwind content

--- a/packages/tailwind-config/src/tailwind.config.ts
+++ b/packages/tailwind-config/src/tailwind.config.ts
@@ -48,6 +48,7 @@ const config = {
     './{src,app}/**/*.{tsx,mdx}',
     './mdx-components.tsx',
     './content/**/*.{md,mdx}',
+    './theme.config.tsx', // Still needed for Nextra 3 websites.
     ...getComponentsPatterns(),
   ],
   theme: {


### PR DESCRIPTION
Added `theme.config.tsx` back to Tailwind config so the logo won't break next time somebody merges a Renovate PR.