### PR TITLE
Add reusable workflow validating MDX links

### DIFF
--- a/.github/workflows/validate-mdx-links.yaml
+++ b/.github/workflows/validate-mdx-links.yaml
@@ -56,4 +56,4 @@ jobs:
           ${{inputs.packageManager}} dlx validate-mdx-links@${{inputs.version}} \
             --cwd ${{inputs.cwd}} \
             --files ${{inputs.files}} \
-            ${{inputs.verbose && '--verbose' || '--no-verbose'}}
+            ${{inputs.verbose && '--verbose' || ''}}


### PR DESCRIPTION
Splitting out a reusable workflow for checking if MDX links are broken from Hive Nextra 4 PR.

The NPM package with the script lives in [my repo](https://github.com/hasparus/eclectic/blob/main/packages/validate-mdx-links) for now. Let me know if you'd like you adopt it :) and I'll send a PR moving it.

Generally, a very good solution for this should probably be implemented inside of Next.js MDX support or inside Nextra.
My script patches some false-positives `next-validate-link` finds, so it's sorta okay. Probably not perfect, but enough that I'm happy with it.