### PR TITLE
V1 corepack

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -60,7 +60,9 @@ runs:
     - name: enable corepack
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: corepack enable
+      run: |
+        npm i -g --force corepack
+        corepack enable
     - name: set up node
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
Because of an issue with `setup-node` action (https://github.com/actions/setup-node/issues/1222), we need to manually update corepack (at least until a proper fix is pushed by maintainers).

The root cause of this is because we run on old Nove version versions which are shipping with outdated corepack version, which are bundled with outdated npm keys...