### PR TITLE
Add functional tones to Tailwind config

### DIFF
--- a/.changeset/moody-buses-suffer.md
+++ b/.changeset/moody-buses-suffer.md
@@ -1,0 +1,5 @@
+---
+"@theguild/tailwind-config": patch
+---
+
+Add functional tones to Tailwind config

--- a/packages/tailwind-config/src/hive-colors.ts
+++ b/packages/tailwind-config/src/hive-colors.ts
@@ -39,4 +39,25 @@ export const hiveColors = {
     900: '#6D6A63',
     1000: '#4D4B46',
   },
+  // primary color functional tones, e.g. for icons in tables
+  // use bright for icons and dark for text on light backgrounds
+  // use dark for icons and bright for text on dark backgrounds
+  'critical-bright': '#FD3325',
+  'critical-dark': '#F81202',
+  'warning-bright': '#FE8830',
+  'positive-bright': '#24D551',
+  'positive-dark': '#1BA13D',
+  // subtle matching functional tones, e.g. for callouts
+  'warning-100': '#FBF8CB',
+  'warning-500': '#E7DE62',
+  'warning-800': '#7D7204',
+  'critical-100': '#FFF0E8',
+  'critical-500': '#FFC6BB',
+  'critical-800': '#932D47',
+  'info-100': '#E7F7FF',
+  'info-500': '#9FC9DC',
+  'info-800': '#205B75',
+  'positive-100': '#F3FBD7',
+  'positive-500': '#AFD563',
+  'positive-800': '#406B10',
 };


### PR DESCRIPTION
Added the functional colors.

<img width="754" alt="image" src="https://github.com/user-attachments/assets/8c1a7f15-6de2-48b7-a6db-90165bcf618b" />
<img width="446" alt="image" src="https://github.com/user-attachments/assets/7928e45f-80c2-4fdd-a438-98cbccbcd73f" />

I currently have these in style tags and I need them in a few more places, so this is gonna help refactor a bit.

They weren't explicitly named in the design system so `bright, dark, 100, 500, 800` is 100% my fault, but I'd like to merge this before the designers have time for proper names (or unifying into one set of colors, but I really don't mind having two for different use cases).
