### PR TITLE
createRequire and log error in Tailwind config

### DIFF
--- a/.changeset/mean-nails-mix.md
+++ b/.changeset/mean-nails-mix.md
@@ -1,0 +1,5 @@
+---
+"@theguild/tailwind-config": patch
+---
+
+createRequire and log error in Tailwind config

--- a/packages/tailwind-config/src/tailwind.config.ts
+++ b/packages/tailwind-config/src/tailwind.config.ts
@@ -32,8 +32,9 @@ function getComponentsPatterns() {
     return [
       path.relative(process.cwd(), path.posix.join(componentsPackageJson, '..', 'dist/**/*.js')),
     ];
-  } catch {
-    console.warn("Can't find `@theguild/components` package.");
+  } catch (err) {
+    console.error("Can't find `@theguild/components` package.");
+    console.error(err);
     return [];
   }
 }

--- a/packages/tailwind-config/src/tailwind.config.ts
+++ b/packages/tailwind-config/src/tailwind.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { type Config } from 'tailwindcss';
 import tailwindContainerQueries from '@tailwindcss/container-queries';
 import { hiveColors } from './hive-colors.js';
+import { createRequire } from 'node:module';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- tailwindcss types are incorrect
 const makePrimaryColor: any =
@@ -15,25 +16,23 @@ const makePrimaryColor: any =
   };
 
 function getComponentsPatterns() {
+  const cwd = process.cwd();
+  let require = globalThis.require;
   try {
-    /**
-     * We explicitly do not use `import { createRequire } from 'node:module'` and
-     * `const require = createRequire(import.meta.url)` because it works even without it.
-     * E.g. storybook complains about cannot found `module` package
-     */
-    const componentsPackageJson = require.resolve('@theguild/components/package.json', {
+    if (typeof require === "undefined") require = createRequire(cwd);
+    
+    const componentsPackageJson = require.resolve("@theguild/components/package.json", {
       /**
        * Paths to resolve module location from CWD. Without specifying, it picks incorrect
        * `@theguild/components`, also must be relative
        */
-      paths: [process.cwd()],
+      paths: [cwd]
     });
-
     return [
-      path.relative(process.cwd(), path.posix.join(componentsPackageJson, '..', 'dist/**/*.js')),
+      path.relative(cwd, path.posix.join(componentsPackageJson, "..", "dist/**/*.js"))
     ];
   } catch (err) {
-    console.error("Can't find `@theguild/components` package.");
+    console.error("Failed to find `@theguild/components` package in ", cwd);
     console.error(err);
     return [];
   }


### PR DESCRIPTION
In Tailwind `3.4.18` we couldn't resolve the components package.json path in Yoga website.

This PR:

1. stops swallowing the error message so we can see what happens in cases like that (we console.error, maybe we should process.exit or throw tho)
2. uses `createRequire` to fix that particular case that broke it in a patch release before