### PR TITLE
Ensure frozen lockfile for all package managers

### DIFF
--- a/.github/workflows/changesets-dependencies.yaml
+++ b/.github/workflows/changesets-dependencies.yaml
@@ -10,15 +10,6 @@ on:
       preCommit:
         type: string
         required: false
-      packageManager:
-        type: string
-        required: false
-        default: yarn
-      packageManagerVersion:
-        type: string
-        description: Package manager version
-        required: false
-        default: ''
       nodeVersion:
         required: false
         type: string
@@ -38,13 +29,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.githubToken }}
 
-      - uses: the-guild-org/shared-config/setup@main
+      - uses: the-guild-org/shared-config/setup@v1
         name: setup env and install dependencies
         if: ${{ inputs.installDependencies }}
         with:
-          nodeVersion: ${{ inputs.nodeVersion }}
-          packageManager: ${{ inputs.packageManager }}
-          packageManagerVersion: ${{ inputs.packageManagerVersion }}
+          node-version: ${{ inputs.nodeVersion }}
 
       - name: Create/Update Changesets
         uses: the-guild-org/changesets-dependencies-action@main

--- a/.github/workflows/changesets-dependencies.yaml
+++ b/.github/workflows/changesets-dependencies.yaml
@@ -10,10 +10,18 @@ on:
       preCommit:
         type: string
         required: false
+
+      # Setup options
       nodeVersion:
         required: false
         type: string
         default: '22'
+      node-version-file:
+        required: false
+        type: string
+      working-directory:
+        required: false
+        type: string
     secrets:
       githubToken:
         required: true
@@ -34,6 +42,8 @@ jobs:
         if: ${{ inputs.installDependencies }}
         with:
           node-version: ${{ inputs.nodeVersion }}
+          node-version-file: ${{ inputs.node-version-file }}
+          working-directory: ${{ inputs.working-directory }}
 
       - name: Create/Update Changesets
         uses: the-guild-org/changesets-dependencies-action@main

--- a/.github/workflows/changesets-dependencies.yml
+++ b/.github/workflows/changesets-dependencies.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   changeset:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout

--- a/.github/workflows/changesets-dependencies.yml
+++ b/.github/workflows/changesets-dependencies.yml
@@ -11,17 +11,21 @@ on:
         type: string
         required: false
 
-      # Setup options
-      nodeVersion:
-        required: false
+      # must match setup/actions.yml
+      node-version:
         type: string
-        default: '22'
+        description: Node.js version to use.
+        required: false
       node-version-file:
-        required: false
         type: string
+        description: File containing the version to use.
+        required: false
       working-directory:
-        required: false
         type: string
+        description: Working directory.
+        required: false
+        default: .
+
     secrets:
       githubToken:
         required: true
@@ -38,10 +42,10 @@ jobs:
           token: ${{ secrets.githubToken }}
 
       - uses: the-guild-org/shared-config/setup@v1
-        name: setup env and install dependencies
+        name: Set up env
         if: ${{ inputs.installDependencies }}
         with:
-          node-version: ${{ inputs.nodeVersion }}
+          node-version: ${{ inputs.node-version }}
           node-version-file: ${{ inputs.node-version-file }}
           working-directory: ${{ inputs.working-directory }}
 

--- a/.github/workflows/ci-node-matrix.yml
+++ b/.github/workflows/ci-node-matrix.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: the-guild-org/shared-config/setup@v1
-        name: setup env
+        name: set up env
         with:
           node-version: ${{matrix.nodeVersion }}
 

--- a/.github/workflows/ci-node-matrix.yml
+++ b/.github/workflows/ci-node-matrix.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ci_setup:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.setVariables.outputs.matrix }}
     steps:
@@ -25,7 +25,7 @@ jobs:
 
   ci:
     needs: ci_setup
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         nodeVersion: ${{fromJson(needs.ci_setup.outputs.matrix)}}

--- a/.github/workflows/ci-node-matrix.yml
+++ b/.github/workflows/ci-node-matrix.yml
@@ -10,16 +10,7 @@ on:
       nodeVersions:
         required: true
         type: string
-        default: '[22]'
-      packageManager:
-        type: string
-        required: false
-        default: yarn
-      packageManagerVersion:
-        type: string
-        description: Package manager version
-        required: false
-        default: ''
+        default: '[18]'
 
 jobs:
   ci_setup:
@@ -44,12 +35,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: the-guild-org/shared-config/setup@main
+      - uses: the-guild-org/shared-config/setup@v1
         name: setup env
         with:
-          nodeVersion: ${{matrix.nodeVersion }}
-          packageManager: ${{inputs.packageManager}}
-          packageManagerVersion: ${{inputs.packageManagerVersion}}
+          node-version: ${{matrix.nodeVersion }}
 
       - name: ${{ inputs.script }}
         run: ${{ inputs.script }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
         type: string
 jobs:
   ci:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     name: ${{ inputs.name || 'script' }}
     steps:
       - name: checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,6 @@ on:
       name:
         required: false
         type: string
-      packageManager:
-        type: string
-        required: false
-        default: yarn
-      packageManagerVersion:
-        type: string
-        description: Package manager version
-        required: false
-        default: ''
 jobs:
   ci:
     runs-on: ubuntu-24.04
@@ -31,12 +22,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: the-guild-org/shared-config/setup@main
+      - uses: the-guild-org/shared-config/setup@v1
         name: setup env
         with:
-          nodeVersion: ${{inputs.nodeVersion}}
-          packageManager: ${{inputs.packageManager}}
-          packageManagerVersion: ${{inputs.packageManagerVersion}}
+          node-version: ${{inputs.nodeVersion}}
 
       - name: ${{ inputs.script }}
         run: ${{ inputs.script }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   eslint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,15 +8,14 @@ on:
         required: false
         type: string
         default: '22'
-      packageManager:
-        type: string
+      annotations:
         required: false
-        default: yarn
-      packageManagerVersion:
-        type: string
-        description: Package manager version
+        type: boolean
+        default: true
+      onlyPrFiles:
         required: false
-        default: ''
+        type: boolean
+        default: true
       script:
         required: false
         type: string
@@ -31,12 +30,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: the-guild-org/shared-config/setup@main
+      - uses: the-guild-org/shared-config/setup@v1
         name: setup env
         with:
-          nodeVersion: ${{inputs.nodeVersion}}
-          packageManager: ${{inputs.packageManager}}
-          packageManagerVersion: ${{inputs.packageManagerVersion}}
+          node-version: ${{inputs.nodeVersion}}
 
       - name: lint
         run: ${{ inputs.script || 'yarn eslint --output-file eslint_report.json --format json .' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,6 @@
 on:
   workflow_call:
     inputs:
-      nodeVersion:
-        required: false
-        type: string
-        default: '22'
       annotations:
         required: false
         type: boolean
@@ -19,6 +15,21 @@ on:
       script:
         required: false
         type: string
+      reportFile:
+        required: false
+        type: string
+        default: eslint_report.json
+
+      # must match setup/actions.yml
+      node-version:
+        type: string
+        description: Node.js version to use.
+        required: false
+      node-version-file:
+        type: string
+        description: File containing the version to use.
+        required: false
+
     secrets:
       githubToken:
         required: false
@@ -31,9 +42,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: the-guild-org/shared-config/setup@v1
-        name: setup env
+        name: set up env
         with:
-          node-version: ${{inputs.nodeVersion}}
+          node-version: ${{ inputs.node-version }}
+          node-version-file: ${{ inputs.node-version-file }}
 
       - name: lint
         run: ${{ inputs.script || 'yarn eslint --output-file eslint_report.json --format json .' }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -4,15 +4,6 @@
 on:
   workflow_call:
     inputs:
-      packageManager:
-        type: string
-        required: false
-        default: yarn
-      packageManagerVersion:
-        description: Package manager version
-        type: string
-        required: false
-        default: ''
       nodeVersion:
         required: false
         type: string
@@ -62,16 +53,15 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: the-guild-org/shared-config/setup@main
+      - uses: the-guild-org/shared-config/setup@v1
+        id: env
         name: setup env
         with:
-          nodeVersion: ${{inputs.nodeVersion}}
-          packageManager: ${{inputs.packageManager}}
-          packageManagerVersion: ${{inputs.packageManagerVersion}}
+          node-version: ${{inputs.nodeVersion}}
 
       - if: inputs.exitPre
         name: Exit Prerelease Mode
-        run: ${{inputs.packageManager}} run changeset pre exit
+        run: ${{steps.env.outputs.package-manager}} run changeset pre exit
 
       - if: inputs.restoreDeletedChangesets
         name: restore deleted changesets
@@ -82,7 +72,7 @@ jobs:
         uses: the-guild-org/changesets-snapshot-action@12ae5b6781ea75c36ece2f2e3446cee6dc093e99 # v0.0.3
         with:
           tag: ${{ inputs.npmTag }}
-          prepareScript: '${{inputs.packageManager}} run ${{ inputs.buildScript }}'
+          prepareScript: '${{steps.env.outputs.package-manager}} run ${{ inputs.buildScript }}'
         env:
           NPM_TOKEN: ${{ secrets.npmToken }}
           GITHUB_TOKEN: ${{ secrets.githubToken }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -4,17 +4,6 @@
 on:
   workflow_call:
     inputs:
-      # Node setup inputs
-      nodeVersion:
-        required: false
-        type: string
-      node-version-file:
-        required: false
-        type: string
-      working-directory:
-        required: false
-        type: string
-
       # Changesets inputs
       buildScript:
         required: false
@@ -32,6 +21,17 @@ on:
         required: false
         type: boolean
         default: false
+
+      # must match setup/actions.yml
+      node-version:
+        type: string
+        description: Node.js version to use.
+        required: false
+      node-version-file:
+        type: string
+        description: File containing the version to use.
+        required: false
+
     secrets:
       githubToken:
         required: true
@@ -66,9 +66,8 @@ jobs:
         id: env
         name: setup env
         with:
-          node-version: ${{inputs.nodeVersion}}
+          node-version: ${{inputs.node-version}}
           node-version-file: ${{inputs.node-version-file}}
-          working-directory: ${{inputs.working-directory}}
 
       - if: inputs.exitPre
         name: Exit Prerelease Mode

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -8,7 +8,6 @@ on:
       buildScript:
         required: false
         type: string
-        default: build
       npmTag:
         required: false
         type: string
@@ -82,7 +81,7 @@ jobs:
         uses: the-guild-org/changesets-snapshot-action@12ae5b6781ea75c36ece2f2e3446cee6dc093e99 # v0.0.3
         with:
           tag: ${{ inputs.npmTag }}
-          prepareScript: '${{steps.env.outputs.package-manager}} run ${{ inputs.buildScript }}'
+          prepareScript: ${{ inputs.buildScript == '' && '' || format('{0} run {1}', steps.env.outputs.package-manager, inputs.buildScript) }}
         env:
           NPM_TOKEN: ${{ secrets.npmToken }}
           GITHUB_TOKEN: ${{ secrets.githubToken }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -50,7 +50,7 @@ on:
 
 jobs:
   snapshot:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       published: ${{ steps.changesets.outputs.published }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -4,10 +4,18 @@
 on:
   workflow_call:
     inputs:
+      # Node setup inputs
       nodeVersion:
         required: false
         type: string
-        default: '22'
+      node-version-file:
+        required: false
+        type: string
+      working-directory:
+        required: false
+        type: string
+
+      # Changesets inputs
       buildScript:
         required: false
         type: string
@@ -29,6 +37,7 @@ on:
         required: true
       npmToken:
         required: true
+
     outputs:
       published:
         description: A boolean value to indicate whether a publishing is happened or not
@@ -58,6 +67,8 @@ jobs:
         name: setup env
         with:
           node-version: ${{inputs.nodeVersion}}
+          node-version-file: ${{inputs.node-version-file}}
+          working-directory: ${{inputs.working-directory}}
 
       - if: inputs.exitPre
         name: Exit Prerelease Mode

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -4,15 +4,6 @@
 on:
   workflow_call:
     inputs:
-      packageManager:
-        type: string
-        required: false
-        default: yarn
-      packageManagerVersion:
-        type: string
-        description: Package manager version
-        required: false
-        default: ''
       nodeVersion:
         required: false
         type: string
@@ -64,12 +55,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.githubToken }}
 
-      - uses: the-guild-org/shared-config/setup@main
+      - uses: the-guild-org/shared-config/setup@v1
+        id: env
         name: setup env
         with:
-          nodeVersion: ${{inputs.nodeVersion}}
-          packageManager: ${{inputs.packageManager}}
-          packageManagerVersion: ${{inputs.packageManagerVersion}}
+          node-version: ${{inputs.nodeVersion}}
 
       - name: set version variables
         id: vars
@@ -82,8 +72,8 @@ jobs:
         id: changesets
         uses: dotansimha/changesets-action@069996e9be15531bd598272996fa23853d61590e # v1.5.2
         with:
-          publish: '${{inputs.packageManager}} ${{ inputs.releaseScript }}'
-          version: '${{inputs.packageManager}} ${{inputs.versionScript}}'
+          publish: '${{steps.env.outputs.package-manager}} ${{ inputs.releaseScript }}'
+          version: '${{steps.env.outputs.package-manager}} ${{inputs.versionScript}}'
           commit: 'chore(release): update monorepo packages versions'
           title: ${{inputs.releasePrName}}
           createGithubReleases: ${{ inputs.createGithubReleases }}

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -51,7 +51,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -4,10 +4,6 @@
 on:
   workflow_call:
     inputs:
-      nodeVersion:
-        required: false
-        type: string
-        default: '22'
       releaseScript:
         required: false
         type: string
@@ -27,6 +23,17 @@ on:
         required: false
         type: string
         default: Upcoming Release Changes
+
+      # must match setup/actions.yml
+      node-version:
+        type: string
+        description: Node.js version to use.
+        required: false
+      node-version-file:
+        type: string
+        description: File containing the version to use.
+        required: false
+
     secrets:
       githubToken:
         required: true
@@ -59,7 +66,8 @@ jobs:
         id: env
         name: setup env
         with:
-          node-version: ${{inputs.nodeVersion}}
+          node-version: ${{inputs.node-version}}
+          node-version-file: ${{inputs.node-version-file}}
 
       - name: set version variables
         id: vars

--- a/README.md
+++ b/README.md
@@ -303,13 +303,12 @@ jobs:
   test:
     name: myScript
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@v3
-
-      - uses: the-guild-org/shared-config/setup@main
-        name: setup env
+      - uses: the-guild-org/shared-config/setup@v1
+        name: set up env
         with:
-          nodeVersion: 22
+          node-version-file: .node-version
 ```
 
 </details>

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -33,6 +33,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: cancel concurrent runs
+      uses: styfle/cancel-workflow-action@0.12.1
+      continue-on-error: true
+      with:
+        access_token: ${{ github.token }}
     - name: detect package manager
       id: pkgmngr
       uses: actions/github-script@v7

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: Working directory.
     required: false
     default: .
+  install-command:
+    type: string
+    description: Custom install command to run after the environment has been set up. Will run instead of the default "install" step.
+    required: false
 
 outputs:
   package-manager:
@@ -60,9 +64,15 @@ runs:
         node-version-file: ${{ inputs.node-version-file }}
         cache: ${{ steps.pkgmngr.outputs.result }}
     - name: install
+      if: inputs.install-command == ""
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: >
         ${{ steps.pkgmngr.outputs.result }} install
         ${{ steps.pkgmngr.outputs.result == 'pnpm' && '--frozen-lockfile' || '' }}
         ${{ steps.pkgmngr.outputs.result == 'yarn' && '--immutable' || '' }}
+    - name: custom install
+      if: inputs.install-command != ""
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: ${{ inputs.install-command }}

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -45,11 +45,11 @@ runs:
         result-encoding: string
         script: |
           const wd = '${{ inputs.working-directory }}';
-          const pkgPath = wd ? `./${wd}/package.json` : 'package.json';
+          const pkgPath = wd ? `./${wd}/package.json` : './package.json';
           let { packageManager } = require(pkgPath);
           if (!packageManager && wd) {
             // try the packageManager from root package json
-            packageManager = require('package.json').packageManager;
+            packageManager = require('./package.json').packageManager;
           }
           if (!packageManager) {
             return core.setFailed(`"packageManager" not defined in "${pkgPath}". Please choose a package manager with "corepack use <your favourite manager>".`);

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -1,85 +1,56 @@
 # Note: This is a composite GitHub Actions, it should do all env setup, caching an so on, so other pipelines can just compose their own stuff on top of that.
 # Docs: https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
 
-name: Configure Environment
-description: Shared configuration for checkout, Node.js and package manager
+name: Setup
+description: |
+  Shared configuration for setting up The Guild's usual environent. It sets up node, detects defined "packageManager", enables corepack and installs with the specified package manager.
+
 inputs:
-  nodeVersion:
-    description: Node.js version to use
-    required: true
-    default: '22'
-  workingDirectory:
-    description: Working directory
+  node-version:
+    description: Node.js version to use.
     required: false
-    default: ./
-  packageManager:
-    description: Package manager
+    default: lts
+  node-version-file:
+    description: File containing the version to use.
     required: false
-    default: yarn
-  packageManagerVersion:
-    description: Package manager version
+  working-directory:
+    description: Working directory.
     required: false
-    default: ''
+    default: .
 
 runs:
   using: composite
   steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+    - name: cancel concurrent runs
+      uses: styfle/cancel-workflow-action@0.12.1
       continue-on-error: true
       with:
         access_token: ${{ github.token }}
-
-    - name: check pnpm version
-      shell: bash
-      id: pnpm
-      if: inputs.packageManager == 'pnpm'
-      working-directory: ${{ inputs.workingDirectory }}
-      run: |
-        PNPM_VERSION=${PNPM_VERSION:-10.6.4}
-        PKG_JSON=$(cat package.json | jq -r '.packageManager' | awk -F@ '{print $2}')
-        if [ ! -z $PKG_JSON ]; then
-          PNPM_VERSION=$PKG_JSON
-        fi
-        if [ ! -z {{inputs.packageManager}} ]; then
-          PNPM_VERSION=${{ inputs.packageManagerVersion }}
-        fi
-        echo "Using PNPM version $PNPM_VERSION"
-        echo "version=$PNPM_VERSION" >> $GITHUB_OUTPUT
-
-    - name: Setup ${{ inputs.packageManager }}
-      id: pnpm_setup
-      if: inputs.packageManager == 'pnpm'
-      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+    - name: detect package manager
+      id: pkgmngr
+      uses: actions/github-script@v7
       with:
-        version: ${{ steps.pnpm.outputs.version }}
-        run_install: false
-        package_json_file: ${{ inputs.workingDirectory }}/package.json
-
-    - name: setup node
-      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        result-encoding: string
+        script: |
+          const pkgPath = '${{ inputs.working-directory }}/package.json';
+          const { packageManager } = require(pkgPath);
+          const [name] = String(packageManager).split('@');
+          if (!name) {
+            return core.setFailed(`"packageManager" not defined in "${pkgPath}". Please choose a package manager with "corepack use <your favourite manager>".`);
+          }
+          console.log(name);
+          return name;
+    - name: enable corepack
+      run: corepack enable
+    - name: set up node
+      uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.nodeVersion }}
-        cache: ${{ inputs.packageManager }}
-        cache-dependency-path: |
-          **/pnpm-lock.yaml
-          **/yarn.lock
-          patches/**
-
-    - name: yarn install
-      shell: bash
-      if: inputs.packageManager == 'yarn' && inputs.packageManagerVersion == ''
-      run: yarn install --ignore-engines --frozen-lockfile --immutable
-      working-directory: ${{ inputs.workingDirectory }}
-
-    - name: modern yarn install
-      shell: bash
-      if: inputs.packageManager == 'yarn' && inputs.packageManagerVersion == 'modern'
-      run: corepack enable && yarn
-      working-directory: ${{ inputs.workingDirectory }}
-
-    - name: pnpm install
-      shell: bash
-      if: inputs.packageManager == 'pnpm'
-      run: pnpm install --frozen-lockfile
-      working-directory: ${{ inputs.workingDirectory }}
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version-file }}
+        cache: ${{ steps.pkgmngr.outputs.result }}
+    - name: install
+      working-directory: ${{ inputs.working-directory }}
+      run: >
+        ${{ steps.pkgmngr.outputs.result }} install
+        ${{ steps.pkgmngr.outputs.result == 'pnpm' && '--frozen-lockfile' || '' }}
+        ${{ steps.pkgmngr.outputs.result == 'yarn' && '--immutable' || '' }}

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -64,7 +64,7 @@ runs:
         node-version-file: ${{ inputs.node-version-file }}
         cache: ${{ steps.pkgmngr.outputs.result }}
     - name: install
-      if: inputs.install-command == ""
+      if: inputs.install-command == ''
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: >
@@ -72,7 +72,7 @@ runs:
         ${{ steps.pkgmngr.outputs.result == 'pnpm' && '--frozen-lockfile' || '' }}
         ${{ steps.pkgmngr.outputs.result == 'yarn' && '--immutable' || '' }}
     - name: custom install
-      if: inputs.install-command != ""
+      if: inputs.install-command != ''
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: ${{ inputs.install-command }}

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -60,7 +60,9 @@ runs:
     - name: enable corepack
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: corepack enable
+      run: |
+        npm i -g --force corepack
+        corepack enable
     - name: set up node
       uses: actions/setup-node@v4
       with:

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: Working directory.
     required: false
     default: .
+outputs:
+  package-manager:
+    description: The detected package manager that is used.
+    value: ${{ steps.pkgmngr.outputs.result }}
 
 runs:
   using: composite

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -41,6 +41,7 @@ runs:
           console.log(name);
           return name;
     - name: enable corepack
+      shell: bash
       run: corepack enable
     - name: set up node
       uses: actions/setup-node@v4
@@ -49,6 +50,7 @@ runs:
         node-version-file: ${{ inputs.node-version-file }}
         cache: ${{ steps.pkgmngr.outputs.result }}
     - name: install
+      shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: >
         ${{ steps.pkgmngr.outputs.result }} install

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -47,10 +47,10 @@ runs:
           const wd = '${{ inputs.working-directory }}';
           const pkgPath = wd ? `./${wd}/package.json` : 'package.json';
           const { packageManager } = require(pkgPath);
-          const [name] = String(packageManager).split('@');
-          if (!name) {
+          if (!packageManager) {
             return core.setFailed(`"packageManager" not defined in "${pkgPath}". Please choose a package manager with "corepack use <your favourite manager>".`);
           }
+          const [name] = packageManager.split('@');
           console.log(name);
           return name;
     - name: enable corepack

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -57,7 +57,8 @@ runs:
           const [name] = packageManager.split('@');
           console.log(name);
           return name;
-    - name: enable corepack      shell: bash
+    - name: enable corepack
+      shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: corepack enable
     - name: set up node

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -45,6 +45,7 @@ runs:
           return name;
     - name: enable corepack
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: corepack enable
     - name: set up node
       uses: actions/setup-node@v4

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -46,15 +46,18 @@ runs:
         script: |
           const wd = '${{ inputs.working-directory }}';
           const pkgPath = wd ? `./${wd}/package.json` : 'package.json';
-          const { packageManager } = require(pkgPath);
+          let { packageManager } = require(pkgPath);
+          if (!packageManager && wd) {
+            // try the packageManager from root package json
+            packageManager = require('package.json').packageManager;
+          }
           if (!packageManager) {
             return core.setFailed(`"packageManager" not defined in "${pkgPath}". Please choose a package manager with "corepack use <your favourite manager>".`);
           }
           const [name] = packageManager.split('@');
           console.log(name);
           return name;
-    - name: enable corepack
-      shell: bash
+    - name: enable corepack      shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: corepack enable
     - name: set up node

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -9,7 +9,6 @@ inputs:
   node-version:
     description: Node.js version to use.
     required: false
-    default: lts
   node-version-file:
     description: File containing the version to use.
     required: false

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -69,7 +69,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
-        cache: ${{ steps.pkgmngr.outputs.result === 'bun' && '' || steps.pkgmngr.outputs.result }}
+        cache: ${{ steps.pkgmngr.outputs.result == 'bun' && '' || steps.pkgmngr.outputs.result }}
     - name: install
       if: inputs.install-command == ''
       shell: bash

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -69,7 +69,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
-        cache: ${{ steps.pkgmngr.outputs.result }}
+        cache: ${{ steps.pkgmngr.outputs.result === 'bun' && '' || steps.pkgmngr.outputs.result }}
     - name: install
       if: inputs.install-command == ''
       shell: bash

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -5,17 +5,22 @@ name: Setup
 description: |
   Shared configuration for setting up The Guild's usual environent. It sets up node, detects defined "packageManager", enables corepack and installs with the specified package manager.
 
+# make sure to match the inputs for all workflows using this action
 inputs:
   node-version:
+    type: string
     description: Node.js version to use.
     required: false
   node-version-file:
+    type: string
     description: File containing the version to use.
     required: false
   working-directory:
+    type: string
     description: Working directory.
     required: false
     default: .
+
 outputs:
   package-manager:
     description: The detected package manager that is used.
@@ -35,7 +40,8 @@ runs:
       with:
         result-encoding: string
         script: |
-          const pkgPath = '${{ inputs.working-directory }}/package.json';
+          const wd = '${{ inputs.working-directory }}';
+          const pkgPath = wd ? `${wd}/package.json` : 'package.json';
           const { packageManager } = require(pkgPath);
           const [name] = String(packageManager).split('@');
           if (!name) {

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -44,8 +44,9 @@ runs:
       with:
         result-encoding: string
         script: |
+          const path = require('path');
           const wd = '${{ inputs.working-directory }}';
-          const pkgPath = wd ? `./${wd}/package.json` : './package.json';
+          const pkgPath = wd ? path.join(wd, './package.json') : './package.json';
           let { packageManager } = require(pkgPath);
           if (!packageManager && wd) {
             // try the packageManager from root package json

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -69,7 +69,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
-        cache: ${{ steps.pkgmngr.outputs.result == 'bun' && '' || steps.pkgmngr.outputs.result }}
+        cache: ${{ steps.pkgmngr.outputs.result != 'bun' && steps.pkgmngr.outputs.result || '' }}
     - name: install
       if: inputs.install-command == ''
       shell: bash

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -45,7 +45,7 @@ runs:
         result-encoding: string
         script: |
           const wd = '${{ inputs.working-directory }}';
-          const pkgPath = wd ? `${wd}/package.json` : 'package.json';
+          const pkgPath = wd ? `./${wd}/package.json` : 'package.json';
           const { packageManager } = require(pkgPath);
           const [name] = String(packageManager).split('@');
           if (!name) {

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -33,11 +33,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: cancel concurrent runs
-      uses: styfle/cancel-workflow-action@0.12.1
-      continue-on-error: true
-      with:
-        access_token: ${{ github.token }}
     - name: detect package manager
       id: pkgmngr
       uses: actions/github-script@v7

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -58,6 +58,9 @@ runs:
           const [name] = packageManager.split('@');
           console.log(name);
           return name;
+    - name: setup bun
+      uses: oven-sh/setup-bun@v2
+      if: steps.pkgmngr.outputs.result == 'bun'
     - name: enable corepack
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -46,7 +46,7 @@ runs:
         script: |
           const path = require('path');
           const wd = '${{ inputs.working-directory }}';
-          const pkgPath = wd ? path.join(wd, './package.json') : './package.json';
+          const pkgPath = (wd != null && wd != '.') ? path.join(wd, './package.json') : './package.json';
           let { packageManager } = require(pkgPath);
           if (!packageManager && wd) {
             // try the packageManager from root package json

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -78,8 +78,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: >
-        ${{ steps.pkgmngr.outputs.result }} install
-        ${{ steps.pkgmngr.outputs.result == 'pnpm' && '--frozen-lockfile' || '' }}
+        ${{ steps.pkgmngr.outputs.result }} ${{ steps.pkgmngr.outputs.result == 'npm' && 'ci' || 'install' }}
+        ${{ (steps.pkgmngr.outputs.result == 'pnpm' || steps.pkgmngr.outputs.result == 'bun') && '--frozen-lockfile' || '' }}
         ${{ steps.pkgmngr.outputs.result == 'yarn' && '--immutable' || '' }}
     - name: custom install
       if: inputs.install-command != ''

--- a/website-cf/action.yml
+++ b/website-cf/action.yml
@@ -96,5 +96,5 @@ runs:
           <!--- ${{ inputs.commentId }} --->
           ### ${{ inputs.commentTitle }}
 
-          The latest changes are available as preview in: [${{ steps.deploy.outputs.url }}](${{ steps.deploy.outputs.url }})
+          The latest changes are available as preview in: [${{ steps.deploy.outputs.deployment-url }}](${{ steps.deploy.outputs.deployment-url }})
         edit-mode: replace


### PR DESCRIPTION
This PR adds necessary flags or commands to ensure the lock-file is never changed in CI:
 - `npm` have a `ci` command as a replacement of `install`
 - `bun` have has the same `--frozen-lockfile` than `pnpm`