### PR TITLE
fix: pin snapshot action with changesets CLI v3 publish parsing

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: ${{ inputs.npmTag }} release
         id: changesets
-        uses: the-guild-org/changesets-snapshot-action@232ff9af22cfd043528fe2e4c403afd090ba3ed3 # v0.0.4
+        uses: ardatan/changesets-action@29038f2da7aa7c2a3c2a44172a53577503d9c13c # fix: parse @changesets/cli v3 publish output
         with:
           tag: ${{ inputs.npmTag }}
           prepareScript: '${{inputs.packageManager}} run ${{ inputs.buildScript }}'


### PR DESCRIPTION
## Summary
- Alpha/rc snapshot workflows post a false *"no linked changesets"* comment after repos move to `@changesets/cli` v3, because the pinned snapshot action only parses the old publish stdout formats.
- Temporarily pin `release-snapshot.yml` to `ardatan/changesets-action@29038f2` (same fix as [the-guild-org/changesets-snapshot-action#3](https://github.com/the-guild-org/changesets-snapshot-action/pull/3)).
- After that PR merges, follow up by pointing back at `the-guild-org/changesets-snapshot-action@<merge-sha>`.

## Test plan
- [ ] Trigger an alpha snapshot on a PR in a repo using `@changesets/cli` ≥ 3 (e.g. graphql-tools) and confirm the PR comment lists published packages.
- [ ] After snapshot-action#3 merges, open a follow-up to restore the `the-guild-org/changesets-snapshot-action` pin.